### PR TITLE
Fix `go generate` for Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,8 @@ go get github.com/rakyll/statik
 
 Generate statik filesystem:
 ```
-go generate ./... # or go generate .\... for windows host os
+go generate ./...
 ```
-
 
 #### Run builder
 ```

--- a/builder.go
+++ b/builder.go
@@ -332,8 +332,7 @@ func runCommands() {
 
 	run := []*command{
 		{"dep", []string{"ensure"}, ""},
-		{"go", []string{"generate",
-			"." + string(filepath.Separator) + "..."}, ""},
+		{"go", []string{"generate", "./..."}, ""},
 		adapterBuild,
 		installerBuild,
 	}


### PR DESCRIPTION
Replased `go generate .\...` to `go generate ./...`.
