### PR TITLE
tap interface name in dappvpn.config

### DIFF
--- a/inst/agent.installer.config.json
+++ b/inst/agent.installer.config.json
@@ -1,5 +1,8 @@
 {
     "Path":"..",
     "Role":"server",
-    "Proto":"tcp"
+    "Proto":"tcp",
+    "Managment": {
+        "Port": 7505
+    }
 }

--- a/inst/client.installer.config.json
+++ b/inst/client.installer.config.json
@@ -1,5 +1,8 @@
 {
     "Path":"..",
     "Role":"client",
-    "Proto":"tcp"
+    "Proto":"tcp",
+    "Managment": {
+        "Port": 7605
+    }
 }

--- a/inst/openvpn/dappvpn.go
+++ b/inst/openvpn/dappvpn.go
@@ -41,6 +41,9 @@ func (d *DappVPN) Configurate(o *OpenVPN) error {
 	maps["FileLog.Filename"] = filepath.Join(p, "log/dappvpn-%Y-%m-%d.log")
 	maps["OpenVPN.Name"] = filepath.Join(p, path.OpenVPN)
 	maps["OpenVPN.ConfigRoot"] = filepath.Join(p, "config")
+	if o.IsWindows {
+		maps["OpenVPN.TapInterface"] = o.Tap.Interface
+	}
 	maps["Pusher.CaCertPath"] = filepath.Join(p, path.CACertificate)
 	maps["Pusher.ConfigPath"] = filepath.Join(p, path.RoleConfig(o.Role))
 

--- a/inst/openvpn/openvpn.go
+++ b/inst/openvpn/openvpn.go
@@ -92,6 +92,7 @@ func (o *OpenVPN) RemoveTap() (err error) {
 // Configurate configurates openvpn config files.
 func (o *OpenVPN) Configurate() error {
 	if o.isClient() {
+		o.Managment.Port = nextFreePort(*o.Managment, "tcp")
 		return nil
 	}
 


### PR DESCRIPTION
Sets tap interface name on Windows.
Sets openvpn managment port to client configuration.
Resolves part of BV-1098.