### PR TITLE
sets openvpn workdir

### DIFF
--- a/inst/command/command.go
+++ b/inst/command/command.go
@@ -60,8 +60,8 @@ func installFlow() pipeline.Flow {
 		newOperator("create config", createConfig, removeConfig),
 		newOperator("create service", createService, removeService),
 		newOperator("create env", createEnv, removeEnv),
-		newOperator("change owner", changeOwner, nil),
 		newOperator("start services", startServices, nil),
+		newOperator("change owner", changeOwner, nil),
 	}
 }
 

--- a/inst/openvpn/execute.go
+++ b/inst/openvpn/execute.go
@@ -29,7 +29,12 @@ func (e *execute) Start() {
 func run(e *execute) error {
 	vpn := filepath.Join(e.Path, path.VPN(e.Type))
 	config := filepath.Join(e.Path, path.VPNConfig(e.Type, e.Role))
-	cmd := exec.Command(vpn, "--config", config)
+	args := []string{}
+	if e.Type == path.Config.OVPN {
+		args = append(args, "--cd", e.Path)
+	}
+	args = append(args, "--config", config)
+	cmd := exec.Command(vpn, args...)
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/inst/openvpn/openvpn.go
+++ b/inst/openvpn/openvpn.go
@@ -262,7 +262,8 @@ func (o *OpenVPN) RunService() (string, error) {
 		return "", err
 	}
 
-	return service.Run(&execute{Path: o.Path, Role: o.Role})
+	return service.Run(&execute{Path: o.Path, Role: o.Role,
+		Type: path.Config.OVPN})
 }
 
 // StopService stops openvpn service.

--- a/statik/ovpn/templates/server-config.tpl
+++ b/statik/ovpn/templates/server-config.tpl
@@ -3,29 +3,29 @@ port {{.Host.Port}}
 proto {{.Proto}}
 dev tun
 {{if not .IsWindows}}#{{end}}dev-node "{{.Tap.Interface}}"
-ca "{{.Path}}/config/ca.crt"
-cert "{{.Path}}/config/server.crt"
-key "{{.Path}}/config/server.key"
-dh "{{.Path}}/config/dh2048.pem"
+ca "config/ca.crt"
+cert "config/server.crt"
+key "config/server.key"
+dh "config/dh2048.pem"
 management {{.Managment.IP}} {{.Managment.Port}}
-auth-user-pass-verify "{{.Path}}/bin/dappvpn{{if .IsWindows}}.exe{{end}} -config={{.Path}}/config/adapter.config.json" via-file
+auth-user-pass-verify "bin/dappvpn{{if .IsWindows}}.exe{{end}} -config config/adapter.config.json" via-file
 verify-client-cert none
 username-as-common-name
-client-connect "{{.Path}}/bin/dappvpn{{if .IsWindows}}.exe{{end}} -config={{.Path}}/config/adapter.config.json"
-client-disconnect "{{.Path}}/bin/dappvpn{{if .IsWindows}}.exe{{end}} -config={{.Path}}/config/adapter.config.json"
+client-connect "bin/dappvpn{{if .IsWindows}}.exe{{end}} -config config/adapter.config.json"
+client-disconnect "bin/dappvpn{{if .IsWindows}}.exe{{end}} -config config/adapter.config.json"
 script-security 3
 tls-server
 server {{.Server.IP}} {{.Server.Mask}}
 push "route {{.Server.IP}} {{.Server.Mask}}"
 push "redirect-gateway def1"
-ifconfig-pool-persist "{{.Path}}/config/ipp.txt"
+ifconfig-pool-persist "config/ipp.txt"
 keepalive 10 120
 comp-lzo
 persist-key
 persist-tun
 {{if .IsWindows}}#{{end}}user {{.User}}
 {{if .IsWindows}}#{{end}}group {{.Group}}
-status "{{.Path}}/log/openvpn-status.log"
-log "{{.Path}}/log/server.log"
-log-append "{{.Path}}/log/server-append.log"
+status "log/openvpn-status.log"
+log "log/server.log"
+log-append "log/server-append.log"
 verb 3


### PR DESCRIPTION
Resolves problems in `openvpn` config file for `agent`:
 1. `maximum option line length (256)` constraints 
 2. spaces in path (on Windows)
